### PR TITLE
Add support for Reply URL on sign out

### DIFF
--- a/source/WsFederationPlugin/Configuration/Hosting/AutofacConfig.cs
+++ b/source/WsFederationPlugin/Configuration/Hosting/AutofacConfig.cs
@@ -51,6 +51,7 @@ namespace IdentityServer3.WsFederation.Configuration
 
             // validators
             builder.RegisterType<SignInValidator>().AsSelf();
+            builder.RegisterType<DefaultRedirectUriValidator>().As<Services.IRedirectUriValidator>();
 
             // processors
             builder.RegisterType<SignInResponseGenerator>().AsSelf();

--- a/source/WsFederationPlugin/Configuration/Hosting/AutofacConfig.cs
+++ b/source/WsFederationPlugin/Configuration/Hosting/AutofacConfig.cs
@@ -48,10 +48,10 @@ namespace IdentityServer3.WsFederation.Configuration
 
             // optional from factory
             builder.RegisterDefaultType<ICustomWsFederationRequestValidator, DefaultCustomWsFederationRequestValidator>(factory.CustomRequestValidator);
+            builder.RegisterDefaultType<Services.IRedirectUriValidator, DefaultRedirectUriValidator>(factory.RedirectUriValidator);
 
             // validators
             builder.RegisterType<SignInValidator>().AsSelf();
-            builder.RegisterType<DefaultRedirectUriValidator>().As<Services.IRedirectUriValidator>();
 
             // processors
             builder.RegisterType<SignInResponseGenerator>().AsSelf();

--- a/source/WsFederationPlugin/Configuration/WsFederationPluginOptions.cs
+++ b/source/WsFederationPlugin/Configuration/WsFederationPluginOptions.cs
@@ -16,6 +16,7 @@
 
 using IdentityServer3.Core.Configuration;
 using System;
+using System.Collections.Generic;
 
 namespace IdentityServer3.WsFederation.Configuration
 {
@@ -42,6 +43,11 @@ namespace IdentityServer3.WsFederation.Configuration
                 return MapPath + "/signout";
             }
         }
+
+        /// <summary>
+        /// Specifies allowed URIs to redirect to after logout
+        /// </summary>
+        public List<string> PostLogoutRedirectUris { get; set; }
 
         /// <summary>
         /// Gets or sets the identity server options.
@@ -94,6 +100,7 @@ namespace IdentityServer3.WsFederation.Configuration
         /// </summary>
         public WsFederationPluginOptions()
         {
+            PostLogoutRedirectUris = new List<string>();
             MapPath = "/wsfed";
             EnableMetadataEndpoint = true;
         }

--- a/source/WsFederationPlugin/Configuration/WsFederationServiceFactory.cs
+++ b/source/WsFederationPlugin/Configuration/WsFederationServiceFactory.cs
@@ -87,6 +87,15 @@ namespace IdentityServer3.WsFederation.Configuration
         /// </value>
         public Registration<ICustomWsFederationRequestValidator> CustomRequestValidator { get; set; }
 
+        // optional
+        /// <summary>
+        /// Gets or sets the redirect URI validator service.
+        /// </summary>
+        /// <value>
+        /// The redirect URI validator service.
+        /// </value>
+        public Registration<Services.IRedirectUriValidator> RedirectUriValidator { get; set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="WsFederationServiceFactory"/> class.
         /// </summary>

--- a/source/WsFederationPlugin/Services/DefaultRedirectUriValidator.cs
+++ b/source/WsFederationPlugin/Services/DefaultRedirectUriValidator.cs
@@ -1,0 +1,67 @@
+﻿/*
+ * Copyright 2015 Dominick Baier, Brock Allen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using IdentityServer3.WsFederation.Configuration;
+
+namespace IdentityServer3.WsFederation.Services
+{
+    /// <summary>
+    /// Default implementation of redirect URI validator. Validates the URIs against
+    /// the trusted URIs configured in the plugin options
+    /// </summary>
+    public class DefaultRedirectUriValidator : IRedirectUriValidator
+    {
+        private readonly WsFederationPluginOptions _wsFedOptions;
+
+        /// <summary>
+        /// Initializes a new instance of the DefaultRedirectUriValidator class
+        /// </summary>
+        /// <param name="wsFedOptions">Plugin options which contain the set of valid redirect URIs</param>
+        public DefaultRedirectUriValidator(WsFederationPluginOptions wsFedOptions)
+        {
+            _wsFedOptions = wsFedOptions;
+        }
+
+        /// <summary>
+        /// Checks if a given URI string is in a collection of strings (using ordinal ignore case comparison)
+        /// </summary>
+        /// <param name="uris">The uris.</param>
+        /// <param name="requestedUri">The requested URI.</param>
+        /// <returns></returns>
+        protected bool StringCollectionContainsString(IEnumerable<string> uris, string requestedUri)
+        {
+            if (uris == null) return false;
+
+            return uris.Contains(requestedUri, StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Determines whether a post logout URI is valid.
+        /// </summary>
+        /// <param name="requestedUri">The requested URI.</param>
+        /// <returns>
+        ///   <c>true</c> is the URI is valid; <c>false</c> otherwise.
+        /// </returns>
+        public virtual Task<bool> IsPostLogoutRedirectUriValidAsync(string requestedUri)
+        {
+            return Task.FromResult(StringCollectionContainsString(_wsFedOptions.PostLogoutRedirectUris, requestedUri));
+        }
+    }
+}

--- a/source/WsFederationPlugin/Services/IRedirectUriValidator.cs
+++ b/source/WsFederationPlugin/Services/IRedirectUriValidator.cs
@@ -1,0 +1,35 @@
+﻿/*
+ * Copyright 2015 Dominick Baier, Brock Allen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Threading.Tasks;
+
+namespace IdentityServer3.WsFederation.Services
+{
+    /// <summary>
+    ///  Models the logic when validating post logout redirect URIs.
+    /// </summary>
+    public interface IRedirectUriValidator
+    {
+        /// <summary>
+        /// Determines whether a post logout URI is valid.
+        /// </summary>
+        /// <param name="requestedUri">The requested URI.</param>
+        /// <returns>
+        ///   <c>true</c> is the URI is valid; <c>false</c> otherwise.
+        /// </returns>
+        Task<bool> IsPostLogoutRedirectUriValidAsync(string requestedUri);
+    }
+}

--- a/source/WsFederationPlugin/WsFederationController.cs
+++ b/source/WsFederationPlugin/WsFederationController.cs
@@ -84,9 +84,7 @@ namespace IdentityServer3.WsFederation
                 if (signout != null)
                 {
                     Logger.Info("WsFederation signout request");
-
-                    var url = this.Request.GetOwinContext().Environment.GetIdentityServerLogoutUrl();
-                    return Redirect(url);
+                    return RedirectToLogOut(signout);
                 }
             }
 
@@ -153,7 +151,7 @@ namespace IdentityServer3.WsFederation
 
             return new SignInResult(responseMessage);
         }
-
+        
         IHttpActionResult RedirectToLogin(SignInValidationResult result)
         {
             Uri publicRequestUri = GetPublicRequestUri();
@@ -175,6 +173,25 @@ namespace IdentityServer3.WsFederation
             var url = env.CreateSignInRequest(message);
             
             return Redirect(url);
+        }
+
+        IHttpActionResult RedirectToLogOut(SignOutRequestMessage msg)
+        {
+            var env = Request.GetOwinEnvironment();
+
+            if (!String.IsNullOrWhiteSpace(msg.Reply))
+            {
+                var message = new SignOutMessage
+                {
+                    ReturnUrl = msg.Reply
+                };
+                
+                var url = env.CreateSignOutRequest(message);
+
+                return Redirect(url);
+            }
+
+            return Redirect(env.GetIdentityServerLogoutUrl());
         }
     }
 }

--- a/source/WsFederationPlugin/WsFederationPlugin.csproj
+++ b/source/WsFederationPlugin/WsFederationPlugin.csproj
@@ -125,7 +125,9 @@
     <Compile Include="Results\SignInResult.cs" />
     <Compile Include="Results\SignOutResult.cs" />
     <Compile Include="Services\DefaultCustomWsFederationRequestValidator.cs" />
+    <Compile Include="Services\DefaultRedirectUriValidator.cs" />
     <Compile Include="Services\InMemoryRelyingPartyService.cs" />
+    <Compile Include="Services\IRedirectUriValidator.cs" />
     <Compile Include="Services\IRelyingPartyService.cs" />
     <Compile Include="Configuration\Hosting\ITrackingCookieService.cs" />
     <Compile Include="Services\ICustomWsFederationRequestValidator.cs" />


### PR DESCRIPTION
Add support for Reply URL on sign out
 - If there is a SignOutRequestMessage Reply URL, validate against a list of trusted URLs. These are configured via WsFederationPluginOptions.PostLogoutRedirectUris.
 - If the RedirectUri is valid create a new SignOutMessage and redirect to the URL provided (with id query string).
 - If the RedirectUri is invalid an `invalid_signout_reply_uri` error is thrown.
 - If no Reply URL was given, use the default IdentityServer logout URL

#29