### PR TITLE
SignInResponseGenerator creates ProfileDataRequestContext with AllCla…

### DIFF
--- a/source/WsFederationPlugin/ResponseHandling/SignInResponseGenerator.cs
+++ b/source/WsFederationPlugin/ResponseHandling/SignInResponseGenerator.cs
@@ -94,7 +94,8 @@ namespace IdentityServer3.WsFederation.ResponseHandling
             {
                 var ctx = new ProfileDataRequestContext
                 {
-                    Subject = validationResult.Subject
+                    Subject = validationResult.Subject,
+                    AllClaimsRequested = true
                 };
                 await _users.GetProfileDataAsync(ctx);
                 


### PR DESCRIPTION
…imsRequested == true when RP requests all claims

Made sure SignInResponseGenerator.CreateSubjectAsync() sets the
AllClaimsRequested property on the ProfileDataRequestContext to true in
the case where the relying party is marked with IncludeAllClaimsForUser.