### PR TITLE
Filter/alter claims on sign in with ICustomWsFederationClaimsService

### DIFF
--- a/source/WsFederationPlugin/Configuration/Hosting/AutofacConfig.cs
+++ b/source/WsFederationPlugin/Configuration/Hosting/AutofacConfig.cs
@@ -48,6 +48,7 @@ namespace IdentityServer3.WsFederation.Configuration
 
             // optional from factory
             builder.RegisterDefaultType<ICustomWsFederationRequestValidator, DefaultCustomWsFederationRequestValidator>(factory.CustomRequestValidator);
+            builder.RegisterDefaultType<ICustomWsFederationClaimsService, DefaultCustomWsFederationClaimsService>(factory.CustomClaimsService);
 
             // validators
             builder.RegisterType<SignInValidator>().AsSelf();

--- a/source/WsFederationPlugin/Configuration/WsFederationServiceFactory.cs
+++ b/source/WsFederationPlugin/Configuration/WsFederationServiceFactory.cs
@@ -86,6 +86,14 @@ namespace IdentityServer3.WsFederation.Configuration
         /// The custom request validator service.
         /// </value>
         public Registration<ICustomWsFederationRequestValidator> CustomRequestValidator { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the custom claims service.
+        /// </summary>
+        /// <value>
+        /// The custom claims service.
+        /// </value>
+        public Registration<ICustomWsFederationClaimsService> CustomClaimsService { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WsFederationServiceFactory"/> class.

--- a/source/WsFederationPlugin/Services/DefaultCustomWsFederationClaimsService.cs
+++ b/source/WsFederationPlugin/Services/DefaultCustomWsFederationClaimsService.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * Copyright 2015 Dominick Baier, Brock Allen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using IdentityServer3.WsFederation.Validation;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace IdentityServer3.WsFederation.Services
+{
+    /// <summary>
+    /// Default custom request validator
+    /// </summary>
+    public class DefaultCustomWsFederationClaimsService : ICustomWsFederationClaimsService
+    {
+        /// <summary>
+        /// Transforms claims before they are sent back to relying party in response to sign in.
+        /// </summary>
+        /// <param name="validationResult">The validated request.</param>
+        /// <param name="mappedClaims">Suggested claims</param>
+        /// <returns>Final claims to include in response</returns>
+        public Task<IEnumerable<Claim>> TransformClaimsAsync(SignInValidationResult validationResult, IEnumerable<Claim> mappedClaims)
+        {
+            return Task.FromResult(mappedClaims);
+        }
+    }
+}

--- a/source/WsFederationPlugin/Services/ICustomWsFederationClaimsService.cs
+++ b/source/WsFederationPlugin/Services/ICustomWsFederationClaimsService.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * Copyright 2015 Dominick Baier, Brock Allen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using IdentityServer3.WsFederation.Validation;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace IdentityServer3.WsFederation.Services
+{
+    /// <summary>
+    /// Implements custom transformation of claims before they are sent back to relying party
+    /// </summary>
+    public interface ICustomWsFederationClaimsService
+    {
+        /// <summary>
+        /// Transforms claims before they are sent back to relying party in response to sign in.
+        /// </summary>
+        /// <param name="validationResult">The validated request.</param>
+        /// <param name="mappedClaims">Suggested claims</param>
+        /// <returns>Final claims to include in response to relying party</returns>
+        Task<IEnumerable<Claim>> TransformClaimsAsync(SignInValidationResult validationResult, IEnumerable<Claim> mappedClaims);
+    }
+}

--- a/source/WsFederationPlugin/WsFederationPlugin.csproj
+++ b/source/WsFederationPlugin/WsFederationPlugin.csproj
@@ -124,7 +124,9 @@
     <Compile Include="Results\MetadataResult.cs" />
     <Compile Include="Results\SignInResult.cs" />
     <Compile Include="Results\SignOutResult.cs" />
+    <Compile Include="Services\DefaultCustomWsFederationClaimsService.cs" />
     <Compile Include="Services\DefaultCustomWsFederationRequestValidator.cs" />
+    <Compile Include="Services\ICustomWsFederationClaimsService.cs" />
     <Compile Include="Services\InMemoryRelyingPartyService.cs" />
     <Compile Include="Services\IRelyingPartyService.cs" />
     <Compile Include="Configuration\Hosting\ITrackingCookieService.cs" />


### PR DESCRIPTION
Hi,

As discussed in #51, allows a custom implementation of the ICustomWsFederationClaimsService to transform the final claims to be used by ClaimsIdentity, created in SignInResponseGenerator.

SignInResponseGenerator simply passes the mappedClaims collection together with the SignInValidationResult to the ICustomWsFederationClaimsService, and uses the result to instantiate the ClaimsIdentity.

As long as the feature is not used, the only extra work performed in runtime is to:
1) instantiate the default DefaultCustomWsFederationClaimsService class, and
2) call that instance with the mappedClaims collection, and use the output, which is the same instance as passed in.

This feature should thus neither cause regressions, nor affect performance, I believe.

Will happily improve the PR if you find any issues, or have better ideas with regard to naming and such.

Thanks,