### PR TITLE
[Updated] Filter/alter claims on sign in with ICustomWsFederationClaimsService

### DIFF
--- a/source/WsFederationPlugin/Configuration/Hosting/AutofacConfig.cs
+++ b/source/WsFederationPlugin/Configuration/Hosting/AutofacConfig.cs
@@ -48,7 +48,7 @@ namespace IdentityServer3.WsFederation.Configuration
 
             // optional from factory
             builder.RegisterDefaultType<ICustomWsFederationRequestValidator, DefaultCustomWsFederationRequestValidator>(factory.CustomRequestValidator);
-
+            builder.RegisterDefaultType<ICustomWsFederationClaimsService, DefaultCustomWsFederationClaimsService>(factory.CustomClaimsService);
             // validators
             builder.RegisterType<SignInValidator>().AsSelf();
 

--- a/source/WsFederationPlugin/Configuration/WsFederationServiceFactory.cs
+++ b/source/WsFederationPlugin/Configuration/WsFederationServiceFactory.cs
@@ -88,6 +88,14 @@ namespace IdentityServer3.WsFederation.Configuration
         public Registration<ICustomWsFederationRequestValidator> CustomRequestValidator { get; set; }
 
         /// <summary>
+        /// Gets or sets the custom claims service.
+        /// </summary>
+        /// <value>
+        /// The custom claims service.
+        /// </value>
+        public Registration<ICustomWsFederationClaimsService> CustomClaimsService { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="WsFederationServiceFactory"/> class.
         /// </summary>
         /// <param name="factory">The factory.</param>

--- a/source/WsFederationPlugin/ResponseHandling/SignInResponseGenerator.cs
+++ b/source/WsFederationPlugin/ResponseHandling/SignInResponseGenerator.cs
@@ -187,7 +187,7 @@ namespace IdentityServer3.WsFederation.ResponseHandling
             }
             mappedClaims.Add(AuthenticationInstantClaim.Now);
 
-            var finalClaims = new List<Claim>(await _customClaimsService.TransformClaimsAsync(validationResult, mappedClaims));
+            var finalClaims = await _customClaimsService.TransformClaimsAsync(validationResult, mappedClaims);
 
             return new ClaimsIdentity(finalClaims, "idsrv");
         }

--- a/source/WsFederationPlugin/Services/DefaultCustomWsFederationClaimsService.cs
+++ b/source/WsFederationPlugin/Services/DefaultCustomWsFederationClaimsService.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * Copyright 2015 Dominick Baier, Brock Allen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using IdentityServer3.WsFederation.Validation;
+
+namespace IdentityServer3.WsFederation.Services
+{
+    /// <summary>
+    /// Default custom request validator
+    /// </summary>
+    public class DefaultCustomWsFederationClaimsService : ICustomWsFederationClaimsService
+    {
+        /// <summary>
+        /// Transforms claims before they are sent back to relying party in response to sign in.
+        /// </summary>
+        /// <param name="validationResult">The validated request.</param>
+        /// <param name="mappedClaims">Suggested claims</param>
+        /// <returns>Final claims to include in response</returns>
+        public Task<IEnumerable<Claim>> TransformClaimsAsync(SignInValidationResult validationResult, IEnumerable<Claim> mappedClaims)
+        {
+            return Task.FromResult(mappedClaims);
+        }
+    }
+}

--- a/source/WsFederationPlugin/Services/ICustomWsFederationClaimsService.cs
+++ b/source/WsFederationPlugin/Services/ICustomWsFederationClaimsService.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * Copyright 2015 Dominick Baier, Brock Allen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using IdentityServer3.WsFederation.Validation;
+
+namespace IdentityServer3.WsFederation.Services
+{
+    /// <summary>
+    /// Implements custom transformation of claims before they are sent back to relying party
+    /// </summary>
+    public interface ICustomWsFederationClaimsService
+    {
+        /// <summary>
+        /// Transforms claims before they are sent back to relying party in response to sign in.
+        /// </summary>
+        /// <param name="validationResult">The validated request.</param>
+        /// <param name="mappedClaims">Suggested claims</param>
+        /// <returns>Final claims to include in response to relying party</returns>
+        Task<IEnumerable<Claim>> TransformClaimsAsync(SignInValidationResult validationResult, IEnumerable<Claim> mappedClaims);
+    }
+}

--- a/source/WsFederationPlugin/WsFederationPlugin.csproj
+++ b/source/WsFederationPlugin/WsFederationPlugin.csproj
@@ -124,7 +124,9 @@
     <Compile Include="Results\MetadataResult.cs" />
     <Compile Include="Results\SignInResult.cs" />
     <Compile Include="Results\SignOutResult.cs" />
+    <Compile Include="Services\DefaultCustomWsFederationClaimsService.cs" />
     <Compile Include="Services\DefaultCustomWsFederationRequestValidator.cs" />
+    <Compile Include="Services\ICustomWsFederationClaimsService.cs" />
     <Compile Include="Services\InMemoryRelyingPartyService.cs" />
     <Compile Include="Services\IRelyingPartyService.cs" />
     <Compile Include="Configuration\Hosting\ITrackingCookieService.cs" />


### PR DESCRIPTION
Updated version of PR #54 by @VictorBlomberg 

Adds support for a `CustomWsFederationClaimsService`, allowing for the transformation of claims based on both user and relying party as discussed in #51. Default service performs no claims transformations.

Claims transformation takes place at the end of `CreateSubjectAsync` method.