### PR TITLE
Ensured relying party is validated before redirecting to login page when the user is unauthenticated

### DIFF
--- a/source/WsFederationPlugin/Validation/SignInValidator.cs
+++ b/source/WsFederationPlugin/Validation/SignInValidator.cs
@@ -56,12 +56,6 @@ namespace IdentityServer3.WsFederation.Validation
                 result.Federation = message.Federation;
             }
 
-            if (!subject.Identity.IsAuthenticated)
-            {
-                result.IsSignInRequired = true;
-                return result;
-            }
-
             // check realm
             var rp = await _relyingParties.GetByRealmAsync(message.Realm);
 
@@ -74,6 +68,12 @@ namespace IdentityServer3.WsFederation.Validation
                     IsError = true,
                     Error = "invalid_relying_party"
                 };
+            }
+
+            if (!subject.Identity.IsAuthenticated)
+            {
+                result.IsSignInRequired = true;
+                return result;
             }
 
             result.ReplyUrl = rp.ReplyUrl;


### PR DESCRIPTION
I've switched the order in which SignInValidator validates the incoming SignInRequestMessage, such that the relying party is validated before redirection to the login page is allowed in the case that the user is not yet authenticated, ensuring that malicious or disabled clients are not presented with the login prompt.